### PR TITLE
fix: move object-fill-missing-keys to the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "rxjs": "^6.6.3",
     "swagger-jsdoc": "^7.0.0-rc.2",
     "swagger-ui-express": "^4.1.6",
-    "typeorm": "^0.2.31"
+    "typeorm": "^0.2.31",
+    "object-fill-missing-keys": "^8.0.8"
   },
   "devDependencies": {
     "@nestjs/cli": "^7.5.1",
@@ -59,7 +60,6 @@
     "eslint-config-prettier": "7.2.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.6.3",
-    "object-fill-missing-keys": "^8.0.8",
     "prettier": "^2.1.2",
     "supertest": "^6.0.0",
     "ts-jest": "^26.4.3",


### PR DESCRIPTION
Heroku build failed